### PR TITLE
refactor add registration date method

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -1,5 +1,5 @@
 class Facility
-  attr_reader :name, :address, :phone, :services, :registered_vehicles
+  attr_reader :name, :address, :phone, :services, :registered_vehicles, :collected_fees
 
   def initialize(facility_details = {})
     @name = facility_details[:name]
@@ -7,6 +7,7 @@ class Facility
     @phone = facility_details[:phone]
     @services = []
     @registered_vehicles = []
+    @collected_fees = 0
   end
 
   def add_service(service)
@@ -17,4 +18,9 @@ class Facility
     @registered_vehicles << vehicle
   end
 
+  def add_registration_date(vehicle, date)
+    if @registered_vehicles.include?(vehicle)
+      vehicle.add_registration_date(date)
+    end
+  end
 end

--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -7,7 +7,9 @@ class Vehicle
               :make,
               :model,
               :engine,
-              :plate_type
+              :plate_type,
+              :registration_date, 
+              :collected_fees
 
   def initialize(vehicle_details = {})
     @vin = vehicle_details[:vin]
@@ -15,8 +17,9 @@ class Vehicle
     @make = vehicle_details[:make]
     @model = vehicle_details[:model]
     @engine = vehicle_details[:engine]
-    @plate_type = vehicle_details[:plate_type]
+    @plate_type = nil
     @registration_date = nil
+    @collected_fees = nil
     
   end
 
@@ -28,16 +31,8 @@ class Vehicle
     @engine == :ev
   end
 
-  def registered?(vehicle)
-    facility.registered_vehicles.include?(vehicle)
+  def add_registration_date(date)
+    @registration_date = date
   end
-
-  def registration_date
-    @registration_date
-  end
-
-  # def add_registration_date(date)
-  #     @registration_date = date
-  # end
 
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
-
+# require 'pry'; binding.pry
 RSpec.describe Facility do
+
   before(:each) do
     @facility_1 = Facility.new({name: 'DMV Tremont Branch', address: '2855 Tremont Place Suite 118 Denver CO 80205', phone: '(720) 865-4600'})
     @facility_2 = Facility.new({name: 'DMV Northeast Branch', address: '4685 Peoria Street Suite 101 Denver CO 80239', phone: '(720) 865-4600'})
@@ -34,7 +35,6 @@ RSpec.describe Facility do
   end
 
   describe '#registration' do
-
     it 'starts with an empty array of registered vehicles' do
 
       expect(@facility_1.registered_vehicles).to eq([])
@@ -43,8 +43,7 @@ RSpec.describe Facility do
 
     it 'can add registered vehicles' do
       @facility_1.register_vehicle(@cruz)
-
+# require 'pry'; binding.pry
       expect(@facility_1.registered_vehicles).to eq([@cruz])
     end
-
 end

--- a/spec/vehicle_spec.rb
+++ b/spec/vehicle_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Vehicle do
       expect(@cruz.make).to eq('Chevrolet')
       expect(@cruz.model).to eq('Cruz')
       expect(@cruz.engine).to eq(:ice)
-      expect(@cruz.registration_date).to eq(nil)
+      # require 'pry';binding.pry
+      expect(@cruz.registration_date).to be_nil
       expect(@cruz.plate_type).to eq(nil)
     end
   end
@@ -47,15 +48,16 @@ RSpec.describe Vehicle do
   end
 
     it 'identifies if a vehicle is registered' do
-
+      # require 'pry'; binding.pry
       expect(@facility_1.registered_vehicles.include?(@cruz)).to eq(true)
     end
 
-    xit 'adds a registration date' do
-      # require 'pry'; binding.pry
-      @facility_1.register_vehicle(@cruz)
-require 'pry'; binding.pry
-      expect(@cruz.add_registration_date("Date: 2023-01-12 ((2459957j,0s,0n),+0s,2299161j")).to eq("Date: 2023-01-12 ((2459957j,0s,0n),+0s,2299161j")
+    it 'adds a registration date when registered' do
+      date = "Date: 2023-01-12 ((2459957j,0s,0n),+0s,2299161j"
+      
+      @facility_1.add_registration_date(@cruz, date)
+
+      expect(@cruz.registration_date).to eq("Date: 2023-01-12 ((2459957j,0s,0n),+0s,2299161j")
     end
   end
 end


### PR DESCRIPTION
This pull request refactors the add registration date method to add a registration date upon a vehicle's registration.

Summary of changes:

Modified add registration date method to add a registration date if a vehicle is added to a facility's registered vehicles array. 