### PR TITLE
add method to add plate type to vehicle when registered

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -23,4 +23,10 @@ class Facility
       vehicle.add_registration_date(date)
     end
   end
+
+  def add_plate_type(vehicle, plate_type)
+    if @registered_vehicles.include?(vehicle)
+      vehicle.add_plate_type(plate_type)
+    end
+  end
 end

--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -35,4 +35,8 @@ class Vehicle
     @registration_date = date
   end
 
+  def add_plate_type(plate_type)
+    @plate_type = plate_type
+  end
+
 end

--- a/spec/vehicle_spec.rb
+++ b/spec/vehicle_spec.rb
@@ -59,5 +59,12 @@ RSpec.describe Vehicle do
 
       expect(@cruz.registration_date).to eq("Date: 2023-01-12 ((2459957j,0s,0n),+0s,2299161j")
     end
+
+    it 'adds a plate type when registered' do
+      plate_type = "regular"
+      @facility_1.add_plate_type(@cruz, plate_type)
+# require 'pry'; binding.pry
+      expect(@cruz.plate_type).to eq("regular")
+    end
   end
 end


### PR DESCRIPTION
This pull request adds a method to add a plate type to a vehicle upon the vehicle's registration at a facility.

Summary of changes:

Added method to replace the default plate type value of nil with a new plate type upon a vehicle's registration at a facility. 